### PR TITLE
Detect autocomplete event

### DIFF
--- a/src/js/floatl.js
+++ b/src/js/floatl.js
@@ -23,7 +23,7 @@ export default class Floatl {
       removeClass(this.element, focusedClass);
     });
 
-    for (var event of ['keyup', 'blur', 'change']) {
+    for (var event of ['keyup', 'blur', 'change', 'input']) {
       addEventListener(this.input, event, () => this._handleChange());
     }
   }


### PR DESCRIPTION
See: http://jsfiddle.net/pYKKp/
Whithout the 'input' event floatl doesn't work when you click on the
input field and select anything from the browser's autocomplete history.